### PR TITLE
Fixed CompositeTypeTest.Save_CompositeType unit test.

### DIFF
--- a/test/FluentCassandra.Tests/TypesToDatabase/CompositeTypeTest.cs
+++ b/test/FluentCassandra.Tests/TypesToDatabase/CompositeTypeTest.cs
@@ -34,7 +34,15 @@ namespace FluentCassandra.TypesToDatabase
 			var expected = new CompositeType<LongType, UTF8Type>(300L, "string1");
 
 			// act
-			family.InsertColumn(TestKey, expected, Math.PI);
+		    var record = family.CreateRecord(TestKey);
+		    var column = record.CreateColumn();
+		    column.ColumnName = expected;
+		    column.ColumnValue = Math.PI;
+
+            record.Columns.Add(column);
+            _db.Attach(record);
+            _db.SaveChanges();
+
 			var value = family.Get(TestKey).Execute();
 			var actual = value.FirstOrDefault().Columns.FirstOrDefault();
 


### PR DESCRIPTION
The unit test wasn't correctly inserting the record into the StandardCompositeType ColumnFamily and was therefore failing. After much heartache, I finally figured out the proper use of the Composite api, and the test is fixed and passes now.
