### PR TITLE
Parsing of composite types

### DIFF
--- a/src/FluentColumn.cs
+++ b/src/FluentColumn.cs
@@ -125,8 +125,8 @@ namespace FluentCassandra
 
 				if (value.HasValue)
 					ColumnSecondsUntilDeleted = Convert.ToInt32(value.Value.TotalSeconds);
-
-				ColumnSecondsUntilDeleted = null;
+                else
+				    ColumnSecondsUntilDeleted = null;
 			}
 		}
 

--- a/src/Operations/Helper.cs
+++ b/src/Operations/Helper.cs
@@ -308,11 +308,16 @@ namespace FluentCassandra.Operations
 
 		public static Column CreateColumn(FluentColumn column)
 		{
-			return new Column {
+			var col = new Column {
 				Name = column.ColumnName.TryToBigEndian(),
 				Value = column.ColumnValue.TryToBigEndian(),
 				Timestamp = column.ColumnTimestamp.ToTimestamp()
 			};
+            if (column.ColumnSecondsUntilDeleted.HasValue)
+            {
+                col.Ttl = column.ColumnSecondsUntilDeleted.Value;
+            }
+            return col;
 		}
 
 		public static ColumnOrSuperColumn CreateColumnOrSuperColumn(IFluentBaseColumn column)

--- a/test/FluentCassandra.Tests/FluentCassandra.Tests.csproj
+++ b/test/FluentCassandra.Tests/FluentCassandra.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -74,6 +74,7 @@
     <Compile Include="TypesToDatabase\LongTypeTest.cs" />
     <Compile Include="TypesToDatabase\UTF8TypeTest.cs" />
     <Compile Include="Types\CompositeTypeTest.cs" />
+    <Compile Include="Types\CassandraTypeTest.cs" />
     <Compile Include="Types\DynamicCompositeTypeTest.cs" />
     <Compile Include="Types\IntegerTypeTest.cs" />
     <Compile Include="CassandraDatabaseSetup.cs" />

--- a/test/FluentCassandra.Tests/Types/CassandraTypeTest.cs
+++ b/test/FluentCassandra.Tests/Types/CassandraTypeTest.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Text;
+using System.Linq;
+using NUnit.Framework;
+
+namespace FluentCassandra.Types
+{
+	[TestFixture]
+	public class CassandraTypeTest
+	{
+		[Test]
+		public void Parse_CompositeType()
+		{
+			// arrange
+			Type expected = typeof(CompositeType<TimeUUIDType, UTF8Type>);
+            string cassandraString = "org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type)";
+
+			// act
+			Type actual = new CassandraType(cassandraString).FluentType;
+
+			// assert
+			Assert.AreEqual(expected, actual);
+		}
+
+        [Test]
+        public void Parse_Type()
+        {
+            // arrange
+            Type expected = typeof(UTF8Type);
+            string cassandraString = "org.apache.cassandra.db.marshal.UTF8Type";
+
+            // act
+            Type actual = new CassandraType(cassandraString).FluentType;
+
+            // assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test, ExpectedException(typeof(CassandraException))]
+        public void Parse_CompositeType_UnknownInnerType()
+        {
+            // arranage
+            string cassandraString = "org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UnkownTypeForTesting)";
+
+            // act
+            Type actual = new CassandraType(cassandraString).FluentType;
+        }
+
+        [Test,ExpectedException(typeof(CassandraException))]
+        public void Parse_UnknownType()
+        {
+            // arranage
+            string cassandraString = "org.apache.cassandra.db.marshal.UnkownTypeForTesting";
+
+            // act
+            Type actual = new CassandraType(cassandraString).FluentType;
+        }
+
+        [Test, ExpectedException(typeof(CassandraException))]
+        public void Parse_UnknownTypeWithParams()
+        {
+            // arranage
+            Type expected = typeof(UTF8Type);
+            string cassandraString = "org.apache.cassandra.db.marshal.UnkownTypeForTesting(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type)";
+
+            // act
+            Type actual = new CassandraType(cassandraString).FluentType;
+        }
+	}
+}


### PR DESCRIPTION
When the schema is loaded from Cassandra I get an exception on composite types, so I've extended the parsing with support for composite types based on the generic classes in fluentcassandra.

Also fixed FluentColumn.ColumnSecondsUntilDeleted and ColumnTimeUntilDeleted that did not work at all.
