### PR TITLE
Small change so that the LINQPad driver loads

### DIFF
--- a/utility/FluentCassandra.LinqPad/SchemaBuilder.cs
+++ b/utility/FluentCassandra.LinqPad/SchemaBuilder.cs
@@ -50,7 +50,7 @@ using FluentCassandra.Types;");
 				throw new ArgumentNullException(""context"", ""context is null."");
 
 			Context = context;
-			Session = new CassandraSession(FluentCassandra.CassandraContext.CurrentConnectionBuilder);
+			Session = new CassandraSession(Context.ConnectionBuilder);
 		}
 
 		public void Dispose()


### PR DESCRIPTION
I wanted to experiment with using LINQPad against Cassandra but the driver wouldn't load.  With this change, it loads, but I still couldn't formulate a query that worked.
