### PR TITLE
Text-based record keys returned from a SuperColumnFamily Range Slice are reversed.

### DIFF
--- a/src/Operations/GetSuperColumnFamilyRangeSlices.cs
+++ b/src/Operations/GetSuperColumnFamilyRangeSlices.cs
@@ -30,7 +30,9 @@ namespace FluentCassandra.Operations
 
 			foreach (var result in output)
 			{
-				var r = new FluentSuperColumnFamily(result.Key, ColumnFamily.FamilyName, schema, result.Columns.Select(col => {
+            var key = CassandraObject.GetCassandraObjectFromDatabaseByteArray(result.Key, schema.KeyValueType);
+
+				var r = new FluentSuperColumnFamily(key, ColumnFamily.FamilyName, schema, result.Columns.Select(col => {
 					var superCol = Helper.ConvertSuperColumnToFluentSuperColumn(col.Super_column, schema);
 					ColumnFamily.Context.Attach(superCol);
 					superCol.MutationTracker.Clear();

--- a/test/FluentCassandra.Tests/Bugs/Issue61SuperColumnRangeSliceKeyBackwards.cs
+++ b/test/FluentCassandra.Tests/Bugs/Issue61SuperColumnRangeSliceKeyBackwards.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentCassandra.Types;
+using Xunit;
+
+namespace FluentCassandra.Bugs
+{
+	public class Issue61SuperColumnRangeSliceKeyBackwards : IUseFixture<CassandraDatabaseSetupFixture>, IDisposable
+	{
+		private CassandraContext _db;
+
+		public void SetFixture(CassandraDatabaseSetupFixture data)
+		{
+			var setup = data.DatabaseSetup();
+			_db = setup.DB;
+		}
+
+		public void Dispose()
+		{
+			_db.Dispose();
+		}
+
+		[Fact]
+		public void Test_GetRangeSlice()
+		{
+			// arrange
+			var keyspace = _db.Keyspace;
+
+			// create column family using API
+			_db.TryDropColumnFamily("supercolumns");
+
+         keyspace.TryCreateColumnFamily(new CassandraColumnFamilySchema
+         {
+            FamilyName = "supercolumns",
+            FamilyType = ColumnType.Super,
+            KeyValueType = CassandraType.UTF8Type,
+            SuperColumnNameType = CassandraType.TimeUUIDType,
+            ColumnNameType = CassandraType.UTF8Type,
+            DefaultColumnValueType = CassandraType.UTF8Type
+         });
+
+		   InsertData("testKey");
+
+			// act
+		   var actual = _db.GetSuperColumnFamily("supercolumns").Get().TakeKeys(5);
+
+			// assert
+			Assert.NotNull(actual);
+			Assert.Equal(1, actual.Count());
+		   Assert.Equal("testKey", actual.First().Key.ToString());
+		}
+
+		public void InsertData(string key)
+		{
+			var productFamily = _db.GetSuperColumnFamily("supercolumns");
+
+         var post = productFamily.CreateRecord(key);
+         _db.Attach(post);
+          
+         for (int i = 0; i < 4; i++)
+		   {
+            dynamic d = post.CreateSuperColumn(GuidGenerator.GenerateTimeBasedGuid(DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(i))));
+		      d.columnone = Guid.NewGuid().ToString();
+		      d.columntwo = Guid.NewGuid().ToString();
+		   }
+
+			_db.SaveChanges();
+		}
+	}
+}

--- a/test/FluentCassandra.Tests/FluentCassandra.Tests.csproj
+++ b/test/FluentCassandra.Tests/FluentCassandra.Tests.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BigDecimalTest.cs" />
+    <Compile Include="Bugs\Issue61SuperColumnRangeSliceKeyBackwards.cs" />
     <Compile Include="Bugs\Issue28GuidGeneratorInParallelContext.cs" />
     <Compile Include="Bugs\Issue25JavaBigDecimalBinaryConversion.cs" />
     <Compile Include="Bugs\Issue36KeyAliasSupport.cs" />
@@ -126,10 +127,10 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-	   Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  Other similar extension points exist, see Microsoft.Common.targets.
+      <Target Name="BeforeBuild">
+      </Target>
+      <Target Name="AfterBuild">
+      </Target>
+      -->
 </Project>


### PR DESCRIPTION
The class GetSuperColumnFamilyRangeSlices does not properly encode the key returned from the range slice query. Therefore, the keys of all the records are reversed.
