### PR TITLE
Fix for issue 54 - Explicitly set timeout when default port is being used

### DIFF
--- a/src/Connections/ConnectionBuilder.cs
+++ b/src/Connections/ConnectionBuilder.cs
@@ -341,7 +341,7 @@ namespace FluentCassandra.Connections
 							Servers.Add(new Server(host: host, timeout: ConnectionTimeout.Seconds));
 					}
 					else
-						Servers.Add(new Server(host));
+                        Servers.Add(new Server(host: host, timeout: ConnectionTimeout.Seconds));
 				}
 			}
 

--- a/test/FluentCassandra.Tests/Bugs/Issue65ServerTimeoutLost.cs
+++ b/test/FluentCassandra.Tests/Bugs/Issue65ServerTimeoutLost.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using FluentCassandra.Connections;
+
+namespace FluentCassandra.Bugs
+{
+    public class Issue65ServerTimeoutLost
+    {
+        [Fact]
+        public void TestSingleServerWithHostAndPort()
+        {
+            Assert.Equal(5, new ConnectionBuilder("Server=host:123;Connection Timeout=5").Servers[0].Timeout);
+        }
+
+        [Fact]
+        public void TestSingleServerWithHostAndDefaultPort()
+        {
+            Assert.Equal(5, new ConnectionBuilder("Server=host;Connection Timeout=5").Servers[0].Timeout);
+        }
+
+        [Fact]
+        public void TestMultipleServersWithHostAndPort()
+        {
+            var servers = new ConnectionBuilder("Server=host:123,host2:456,host3:789;Connection Timeout=5").Servers;
+            Assert.Equal(3, servers.Count);
+            foreach (var server in servers)
+            {
+                Assert.Equal(5, server.Timeout);
+            }
+        }
+
+        [Fact]
+        public void TestMultipleServersWithHostAndDefaultPort()
+        {
+            var servers = new ConnectionBuilder("Server=host,host2,host3;Connection Timeout=5").Servers;
+            Assert.Equal(3, servers.Count);
+            foreach (var server in servers)
+            {
+                Assert.Equal(5, server.Timeout);
+            }
+        }
+
+        [Fact]
+        public void TestMultipleServersWithHostAndMixedPorts()
+        {
+            var servers = new ConnectionBuilder("Server=host:123,host2,host3:789;Connection Timeout=5").Servers;
+            Assert.Equal(3, servers.Count);
+            foreach (var server in servers)
+            {
+                Assert.Equal(5, server.Timeout);
+            }
+        }
+    }
+}

--- a/test/FluentCassandra.Tests/FluentCassandra.Tests.csproj
+++ b/test/FluentCassandra.Tests/FluentCassandra.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Bugs\Issue25JavaBigDecimalBinaryConversion.cs" />
     <Compile Include="Bugs\Issue36KeyAliasSupport.cs" />
     <Compile Include="Bugs\Issue39CompositeTypeAsKey.cs" />
+    <Compile Include="Bugs\Issue65ServerTimeoutLost.cs" />
     <Compile Include="CassandraDatabaseSetupFixture.cs" />
     <Compile Include="CassandraQueryTest.cs" />
     <Compile Include="Connections\ConnectionProviderTests.cs" />


### PR DESCRIPTION
Fixed the code suggested as a problem in issue #54.  Added unit tests.
