### PR TITLE
Trimming strings while parsing the connection string to allow for more f...

### DIFF
--- a/src/Connections/ConnectionBuilder.cs
+++ b/src/Connections/ConnectionBuilder.cs
@@ -82,7 +82,7 @@ namespace FluentCassandra.Connections
 				if (nameValue.Length != 2)
 					continue;
 
-				pairs.Add(nameValue[0], nameValue[1]);
+                pairs.Add(nameValue[0].Trim(), nameValue[1].Trim());
 			}
 
 			#region Keyspace
@@ -330,12 +330,12 @@ namespace FluentCassandra.Connections
 				foreach (var server in servers)
 				{
 					string[] serverParts = server.Split(':');
-					string host = serverParts[0];
+                    string host = serverParts[0].Trim();
 
 					if (serverParts.Length == 2)
 					{
 						int port;
-						if (Int32.TryParse(serverParts[1], out port))
+                        if (Int32.TryParse(serverParts[1].Trim(), out port))
 							Servers.Add(new Server(host: host, port: port, timeout: ConnectionTimeout.Seconds));
 						else
 							Servers.Add(new Server(host: host, timeout: ConnectionTimeout.Seconds));

--- a/test/FluentCassandra.Tests/Connections/ConnectionBuilderTests.cs
+++ b/test/FluentCassandra.Tests/Connections/ConnectionBuilderTests.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using System.Configuration;
+
+namespace FluentCassandra.Connections
+{
+    public class ConnectionBuilderTests
+    {
+        [Fact]
+        public void SpacesBeforeServerHostnamesTest()
+        {
+            // arrange
+            IList<Server> expected = new List<Server>();
+            expected.Add(new Server("test-host-1"));
+            expected.Add(new Server("test-host-2"));
+            expected.Add(new Server("test-host-3"));
+            string connectionString = string.Format("Keyspace={0};Server={1}, {2}, {3};Pooling=True", ConfigurationManager.AppSettings["TestKeySpace"], expected[0].Host, expected[1].Host, expected[2].Host);
+            // act
+            IList<Server> actual = new ConnectionBuilder(connectionString).Servers;
+
+            // assert
+            Assert.Equal(expected.Count, actual.Count);
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Server e = expected[i];
+                Server a = actual[i];
+                Assert.Equal(e.Host, a.Host);
+            }
+        }
+
+        [Fact]
+        public void SpacesAfterServerHostnamesTest()
+        {
+            // arrange
+            IList<Server> expected = new List<Server>();
+            expected.Add(new Server("test-host-1"));
+            expected.Add(new Server("test-host-2"));
+            expected.Add(new Server("test-host-3"));
+            string connectionString = string.Format("Keyspace={0};Server={1} ,{2} ,{3};Pooling=True", ConfigurationManager.AppSettings["TestKeySpace"], expected[0].Host, expected[1].Host, expected[2].Host);
+            // act
+            IList<Server> actual = new ConnectionBuilder(connectionString).Servers;
+
+            // assert
+            Assert.Equal(expected.Count, actual.Count);
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Server e = expected[i];
+                Server a = actual[i];
+                Assert.Equal(e.Host, a.Host);
+            }
+        }
+
+        [Fact]
+        public void NormalServerHostnamesTest()
+        {
+            // arrange
+            IList<Server> expected = new List<Server>();
+            expected.Add(new Server("test-host-1"));
+            expected.Add(new Server("test-host-2"));
+            expected.Add(new Server("test-host-3"));
+            string connectionString = string.Format("Keyspace={0};Server={1},{2},{3};Pooling=True", ConfigurationManager.AppSettings["TestKeySpace"], expected[0].Host, expected[1].Host, expected[2].Host);
+            // act
+            IList<Server> actual = new ConnectionBuilder(connectionString).Servers;
+
+            // assert
+            Assert.Equal(expected.Count, actual.Count);
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Server e = expected[i];
+                Server a = actual[i];
+                Assert.Equal(e.Host, a.Host);
+            }
+        }
+
+        [Fact]
+        public void LeadingAndTralingSpacesOnKeyTest()
+        {
+            // arrange
+            string expectedKeyspace = ConfigurationManager.AppSettings["TestKeySpace"];
+            IList<Server> expected = new List<Server>();
+            expected.Add(new Server("test-host-1"));
+            expected.Add(new Server("test-host-2"));
+            expected.Add(new Server("test-host-3"));
+            string connectionString = string.Format(" Keyspace ={0}; Server ={1},{2},{3}; Pooling =True", ConfigurationManager.AppSettings["TestKeySpace"], expected[0].Host, expected[1].Host, expected[2].Host);
+            // act
+            ConnectionBuilder result = new ConnectionBuilder(connectionString);
+            IList<Server> actual = result.Servers;
+            string actualKeyspace = result.Keyspace;
+            // assert
+            Assert.True(result.Pooling);
+            Assert.Equal(expectedKeyspace, actualKeyspace);
+            Assert.Equal(expected.Count, actual.Count);
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Server e = expected[i];
+                Server a = actual[i];
+                Assert.Equal(e.Host, a.Host);
+            }
+        }
+
+        [Fact]
+        public void LeadingAndTralingSpacesOnValueTest()
+        {
+            // arrange
+            string expectedKeyspace = ConfigurationManager.AppSettings["TestKeySpace"];
+            IList<Server> expected = new List<Server>();
+            expected.Add(new Server("test-host-1"));
+            expected.Add(new Server("test-host-2"));
+            expected.Add(new Server("test-host-3"));
+            string connectionString = string.Format("Keyspace= {0} ;Server= {1},{2},{3} ;Pooling= True ", ConfigurationManager.AppSettings["TestKeySpace"], expected[0].Host, expected[1].Host, expected[2].Host);
+            // act
+            ConnectionBuilder result = new ConnectionBuilder(connectionString);
+            IList<Server> actual = result.Servers;
+            string actualKeyspace = result.Keyspace;
+            // assert
+            Assert.True(result.Pooling);
+            Assert.Equal(expectedKeyspace, actualKeyspace);
+            Assert.Equal(expected.Count, actual.Count);
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Server e = expected[i];
+                Server a = actual[i];
+                Assert.Equal(e.Host, a.Host);
+            }
+        }
+    }
+}

--- a/test/FluentCassandra.Tests/FluentCassandra.Tests.csproj
+++ b/test/FluentCassandra.Tests/FluentCassandra.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Bugs\Issue65ServerTimeoutLost.cs" />
     <Compile Include="CassandraDatabaseSetupFixture.cs" />
     <Compile Include="CassandraQueryTest.cs" />
+    <Compile Include="Connections\ConnectionBuilderTests.cs" />
     <Compile Include="Connections\ConnectionProviderTests.cs" />
     <Compile Include="Connections\NormalConnectionProviderTests.cs" />
     <Compile Include="CqlHelperTest.cs" />


### PR DESCRIPTION
...lexibility with spaces around the connection string key/value pairs.

Accompanied with new unit tests.

This all stemmed from me accidentally putting something like the following in the connection string: "...Server=my-host-1, my-host-2, my-host-3;..."  And because of those spaces DNS lookup was failing on all but the first in the list causing round-robin not to work.
I could see the same thing happening for other users on both the Servers tag and other key/value pairs so I think it makes sense to accommodate it.
