### PR TITLE
One session per context

### DIFF
--- a/src/CassandraContext.cs
+++ b/src/CassandraContext.cs
@@ -47,11 +47,11 @@ namespace FluentCassandra
 		/// 
 		/// </summary>
 		/// <param name="session"></param>
-        public CassandraContext(CassandraSession session) 
-            : this(session.ConnectionBuilder)
-        {
-		    _session = session;
-		    _isOutsideSession = true;
+		public CassandraContext(CassandraSession session)
+			: this(session.ConnectionBuilder)
+		{
+			_session = session;
+			_isOutsideSession = true;
 		}
 
 		/// <summary>
@@ -63,7 +63,7 @@ namespace FluentCassandra
 			ThrowErrors = true;
 
 			_trackers = new List<IFluentMutationTracker>();
-            ConnectionBuilder = connectionBuilder;
+			ConnectionBuilder = connectionBuilder;
 
 			Keyspace = new CassandraKeyspace(ConnectionBuilder.Keyspace, this);
 		}

--- a/src/CassandraContext.cs
+++ b/src/CassandraContext.cs
@@ -47,11 +47,11 @@ namespace FluentCassandra
 		/// 
 		/// </summary>
 		/// <param name="session"></param>
-		public CassandraContext(CassandraSession session)
-			: this(session.ConnectionBuilder)
-		{
-			_session = session;
-			_isOutsideSession = true;
+        public CassandraContext(CassandraSession session) 
+            : this(session.ConnectionBuilder)
+        {
+		    _session = session;
+		    _isOutsideSession = true;
 		}
 
 		/// <summary>
@@ -63,7 +63,7 @@ namespace FluentCassandra
 			ThrowErrors = true;
 
 			_trackers = new List<IFluentMutationTracker>();
-			ConnectionBuilder = connectionBuilder;
+            ConnectionBuilder = connectionBuilder;
 
 			Keyspace = new CassandraKeyspace(ConnectionBuilder.Keyspace, this);
 		}
@@ -370,26 +370,15 @@ namespace FluentCassandra
 		{
 			if (WasDisposed)
 				throw new ObjectDisposedException(GetType().FullName);
-
-			var localSession = _session == null;
-			var session = _session;
-			if (session == null)
-				session = new CassandraSession(ConnectionBuilder);
+            if(_session == null)
+                _session = new CassandraSession(ConnectionBuilder);
 
 			action.Context = this;
+          
+            var result = _session.ExecuteOperation(action, throwOnError ?? ThrowErrors);
+            LastError = _session.LastError;
 
-			try
-			{
-				var result = session.ExecuteOperation(action, throwOnError ?? ThrowErrors);
-				LastError = session.LastError;
-
-				return result;
-			}
-			finally
-			{
-				if (localSession && session != null)
-					session.Dispose();
-			}
+			return result;
 		}
 
 		#region IDisposable Members


### PR DESCRIPTION
Removed the concept of local session inside execute and instead lazy initialize a single CassandraSession per CassandraContext
