### PR TITLE
Fix BigDecimal bug

### DIFF
--- a/FluentCassandra_All.sln
+++ b/FluentCassandra_All.sln
@@ -45,8 +45,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EAA32600-3C2A-4B34-B9B2-5764F280FCE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EAA32600-3C2A-4B34-B9B2-5764F280FCE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EAA32600-3C2A-4B34-B9B2-5764F280FCE3}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{EAA32600-3C2A-4B34-B9B2-5764F280FCE3}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{EAA32600-3C2A-4B34-B9B2-5764F280FCE3}.Debug|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{EAA32600-3C2A-4B34-B9B2-5764F280FCE3}.Debug|Mixed Platforms.Build.0 = Release|Any CPU
 		{EAA32600-3C2A-4B34-B9B2-5764F280FCE3}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{EAA32600-3C2A-4B34-B9B2-5764F280FCE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EAA32600-3C2A-4B34-B9B2-5764F280FCE3}.Release|Any CPU.Build.0 = Release|Any CPU
@@ -55,7 +55,6 @@ Global
 		{EAA32600-3C2A-4B34-B9B2-5764F280FCE3}.Release|x86.ActiveCfg = Release|Any CPU
 		{DE6B46DE-C37A-49AF-8B9A-B9B6D4F03A55}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{DE6B46DE-C37A-49AF-8B9A-B9B6D4F03A55}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{DE6B46DE-C37A-49AF-8B9A-B9B6D4F03A55}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{DE6B46DE-C37A-49AF-8B9A-B9B6D4F03A55}.Debug|x86.ActiveCfg = Debug|x86
 		{DE6B46DE-C37A-49AF-8B9A-B9B6D4F03A55}.Debug|x86.Build.0 = Debug|x86
 		{DE6B46DE-C37A-49AF-8B9A-B9B6D4F03A55}.Release|Any CPU.ActiveCfg = Release|x86
@@ -65,7 +64,6 @@ Global
 		{DE6B46DE-C37A-49AF-8B9A-B9B6D4F03A55}.Release|x86.Build.0 = Release|x86
 		{AC3818E2-E260-4193-A3D1-6E3FF87383F6}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{AC3818E2-E260-4193-A3D1-6E3FF87383F6}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{AC3818E2-E260-4193-A3D1-6E3FF87383F6}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{AC3818E2-E260-4193-A3D1-6E3FF87383F6}.Debug|x86.ActiveCfg = Debug|x86
 		{AC3818E2-E260-4193-A3D1-6E3FF87383F6}.Debug|x86.Build.0 = Debug|x86
 		{AC3818E2-E260-4193-A3D1-6E3FF87383F6}.Release|Any CPU.ActiveCfg = Release|x86
@@ -76,7 +74,6 @@ Global
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Release|Any CPU.Build.0 = Release|Any CPU
@@ -85,7 +82,6 @@ Global
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Release|x86.ActiveCfg = Release|Any CPU
 		{CACA3463-BBEE-4C7E-AC89-49240B0D8F46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CACA3463-BBEE-4C7E-AC89-49240B0D8F46}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{CACA3463-BBEE-4C7E-AC89-49240B0D8F46}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{CACA3463-BBEE-4C7E-AC89-49240B0D8F46}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{CACA3463-BBEE-4C7E-AC89-49240B0D8F46}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CACA3463-BBEE-4C7E-AC89-49240B0D8F46}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU

--- a/src/System/Numerics/BigDecimal.cs
+++ b/src/System/Numerics/BigDecimal.cs
@@ -58,8 +58,8 @@ namespace System.Numerics
 			byte[] number = new byte[value.Length - 4];
 			byte[] flags = new byte[4];
 
-			Array.Copy(value, 0, number, 0, number.Length);
-			Array.Copy(value, value.Length - 4, flags, 0, 4);
+            Array.Copy(value, 0, flags, 0, 4);
+            Array.Copy(value, 0, number, flags.Length, number.Length);
 
 			_unscaledValue = new BigInteger(number);
 			_scale = BitConverter.ToInt32(flags, 0);
@@ -87,8 +87,8 @@ namespace System.Numerics
 			var scale = BitConverter.GetBytes(_scale);
 
 			var bytes = new byte[unscaledValue.Length + scale.Length];
-			Array.Copy(unscaledValue, 0, bytes, 0, unscaledValue.Length);
-			Array.Copy(scale, 0, bytes, unscaledValue.Length, scale.Length);
+            Array.Copy(scale, 0, bytes, 0, scale.Length);
+            Array.Copy(unscaledValue, 0, bytes, scale.Length, unscaledValue.Length);
 
 			return bytes;
 		}

--- a/src/System/Numerics/BigDecimal.cs
+++ b/src/System/Numerics/BigDecimal.cs
@@ -58,8 +58,8 @@ namespace System.Numerics
 			byte[] number = new byte[value.Length - 4];
 			byte[] flags = new byte[4];
 
-            Array.Copy(value, 0, flags, 0, 4);
-            Array.Copy(value, 0, number, flags.Length, number.Length);
+			Array.Copy(value, 0, number, 0, number.Length);
+			Array.Copy(value, value.Length - 4, flags, 0, 4);
 
 			_unscaledValue = new BigInteger(number);
 			_scale = BitConverter.ToInt32(flags, 0);
@@ -87,8 +87,8 @@ namespace System.Numerics
 			var scale = BitConverter.GetBytes(_scale);
 
 			var bytes = new byte[unscaledValue.Length + scale.Length];
-            Array.Copy(scale, 0, bytes, 0, scale.Length);
-            Array.Copy(unscaledValue, 0, bytes, scale.Length, unscaledValue.Length);
+			Array.Copy(unscaledValue, 0, bytes, 0, unscaledValue.Length);
+			Array.Copy(scale, 0, bytes, unscaledValue.Length, scale.Length);
 
 			return bytes;
 		}

--- a/src/Types/CassandraConversionHelper.cs
+++ b/src/Types/CassandraConversionHelper.cs
@@ -60,7 +60,27 @@ namespace FluentCassandra.Types
 			var buffer = (byte[])value.Clone();
 			Array.Reverse(buffer);
 
-			return new BigDecimal(buffer);
+            byte[] number = new byte[value.Length - 4];
+            byte[] flags = new byte[4];
+            Array.Copy(buffer, 0, flags, 0, 4);
+            Array.Copy(buffer, 0, number, flags.Length, number.Length);
+
+            BigInteger unscaledValue = new BigInteger(number);
+            int scale = System.BitConverter.ToInt32(flags, 0);
+
+            return new BigDecimal(unscaledValue, scale);
 		}
+
+        internal static byte[] ToBytes(BigDecimal value)
+        {
+            byte[] nativeBytes = (byte[])value.ToByteArray().Clone();
+            byte[] bytes = new byte[nativeBytes.Length];
+
+            // first copy the scale bytes
+            Array.Copy(nativeBytes, nativeBytes.Length - 4, bytes, 0, 4);
+            // second copy the unscaled bytes
+            Array.Copy(nativeBytes, 0, bytes, 4, nativeBytes.Length - 4);
+            return bytes;
+        }
 	}
 }

--- a/src/Types/CassandraConversionHelper.cs
+++ b/src/Types/CassandraConversionHelper.cs
@@ -71,9 +71,10 @@ namespace FluentCassandra.Types
             return new BigDecimal(unscaledValue, scale);
 		}
 
-        internal static byte[] ToBytes(BigDecimal value)
+        internal static byte[] ToBigEndianBytes(BigDecimal value)
         {
             byte[] nativeBytes = (byte[])value.ToByteArray().Clone();
+            Array.Reverse(nativeBytes);
             byte[] bytes = new byte[nativeBytes.Length];
 
             // first copy the scale bytes


### PR DESCRIPTION
The first 4 bytes of Decimal types should be the scale and the remaining bytes the BigInteger. This fixes the bug, so that it is correct. With it reversed as it is currently, cassandra-cli will get a stack overflow when you do a list my_cf. Clients written in other languages/platforms would also likely crash.
