### PR TITLE
Blacklist Refactoring

### DIFF
--- a/FluentCassandra.sln
+++ b/FluentCassandra.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{1A88B962
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentCassandra.Tests", "test\FluentCassandra.Tests\FluentCassandra.Tests.csproj", "{9DAF7022-5820-4214-B13E-AC0A1B37691F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestPoolExhaustion", "..\..\dev\BTCassandra.Interop\ConsoleApplication2\TestPoolExhaustion.csproj", "{63108852-4D94-4726-8EE3-5DE5D50963E8}"
+EndProject
 Global
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = FluentCassandra.vsmdi
@@ -63,6 +65,16 @@ Global
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Release|x86.ActiveCfg = Release|Any CPU
+		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Debug|x86.ActiveCfg = Debug|x86
+		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Debug|x86.Build.0 = Debug|x86
+		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Release|Any CPU.ActiveCfg = Release|x86
+		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Release|Mixed Platforms.Build.0 = Release|x86
+		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Release|x86.ActiveCfg = Release|x86
+		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FluentCassandra.sln
+++ b/FluentCassandra.sln
@@ -20,8 +20,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{1A88B962
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentCassandra.Tests", "test\FluentCassandra.Tests\FluentCassandra.Tests.csproj", "{9DAF7022-5820-4214-B13E-AC0A1B37691F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestPoolExhaustion", "..\..\dev\BTCassandra.Interop\ConsoleApplication2\TestPoolExhaustion.csproj", "{63108852-4D94-4726-8EE3-5DE5D50963E8}"
-EndProject
 Global
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = FluentCassandra.vsmdi
@@ -65,16 +63,6 @@ Global
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{9DAF7022-5820-4214-B13E-AC0A1B37691F}.Release|x86.ActiveCfg = Release|Any CPU
-		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Debug|Mixed Platforms.Build.0 = Debug|x86
-		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Debug|x86.ActiveCfg = Debug|x86
-		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Debug|x86.Build.0 = Debug|x86
-		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Release|Any CPU.ActiveCfg = Release|x86
-		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Release|Mixed Platforms.Build.0 = Release|x86
-		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Release|x86.ActiveCfg = Release|x86
-		{63108852-4D94-4726-8EE3-5DE5D50963E8}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Connections/Connection.cs
+++ b/src/Connections/Connection.cs
@@ -16,7 +16,6 @@ namespace FluentCassandra.Connections
 		private Cassandra.Client _client;
 		private string _activeKeyspace;
 		private string _activeCqlVersion;
-		private bool _healthy;
 		private readonly object _lock = new object();
 
 		/// <summary>
@@ -39,7 +38,6 @@ namespace FluentCassandra.Connections
 			Server = server;
 			ConnectionType = connectionType;
 			BufferSize = bufferSize;
-			_healthy = true;
 			InitTransportAndClient();
 		}
 

--- a/src/Connections/IConnectionBuilder.cs
+++ b/src/Connections/IConnectionBuilder.cs
@@ -15,9 +15,9 @@ namespace FluentCassandra.Connections
 		int MaxRetries { get; }
 		TimeSpan ConnectionTimeout { get; }
 		TimeSpan ConnectionLifetime { get; }
+        TimeSpan ServerRecoveryInterval { get; }
 		ConnectionType ConnectionType { get; }
-
-		int BufferSize { get; }
+        int BufferSize { get; }
 		ConsistencyLevel ReadConsistency { get; }
 		ConsistencyLevel WriteConsistency { get; }
 


### PR DESCRIPTION
Some bug fixes and small tweaks to the blacklisting enhancements.

**Bug Fixes**
- When removing a server from the blacklist it was not being sent back to the serverqueue
- Added some additional exception types to handle in Operation::TryExecute()
- Added an additional input parameter on Operation::ExceptionOccuredRetryExecution called: bool markClientAsUnhealthy so that we can selectively blacklist a server when retrying.
- In Operation::TryExecute() after Execute() is called must mark HasError = false and Error = null. If not and there is an exception thrown on the first pass but the next pass results in a valid execution the exception was still being thrown.

**Additions**
- Added ServerRecoveryInterval to ConnectionString/Builder.
- Turned the recovery timer into a "one shot" timer and calling the Timer::Change() method at the end of the callback to avoid potential overlap. We could consider using Timers.Timer but then we'd need to think about to handle overlap there as well. Potentially with a Monitor.TryEnter? I am open to suggestions.
