### PR TITLE
Fixed bug with retrieving CounterColumns

### DIFF
--- a/src/FluentColumnFamily.cs
+++ b/src/FluentColumnFamily.cs
@@ -189,7 +189,7 @@ namespace FluentCassandra
 			if (colSchema != null)
 				return colSchema;
 
-			return new CassandraColumnSchema { NameType = schema.ColumnNameType, ValueType = typeof(BytesType) };
+			return new CassandraColumnSchema { NameType = schema.ColumnNameType, ValueType = schema.DefaultColumnValueType ?? typeof(BytesType) };
 		}
 
 		/// <summary>

--- a/src/Operations/Helper.cs
+++ b/src/Operations/Helper.cs
@@ -144,9 +144,9 @@ namespace FluentCassandra.Operations
 			else if (col.Column != null)
 				return ConvertColumnToFluentColumn(col.Column, schema);
 			else if (col.Counter_super_column != null)
-				return ConvertColumnToFluentCounterColumn(col.Counter_column, schema);
+                return ConvertSuperColumnToFluentCounterSuperColumn(col.Counter_super_column, schema);
 			else if (col.Counter_column != null)
-				return ConvertSuperColumnToFluentCounterSuperColumn(col.Counter_super_column, schema);
+                return ConvertColumnToFluentCounterColumn(col.Counter_column, schema);
 			else
 				return null;
 		}


### PR DESCRIPTION
Lines 

https://github.com/managedfusion/fluentcassandra/blob/master/src/Operations/Helper.cs#L147

and 

https://github.com/managedfusion/fluentcassandra/blob/master/src/Operations/Helper.cs#L149

are flipped - FluentCassandra was attempting to convert CounterColumns into FluentSuperCounterColumns and SuperCounterColumns into FluentCounterColumns. 

2d5df1e - addresses that issue

commit d74bf60 sets it so any column created via FluentColumnFamily.CreateColumn() gets the default validator from the ColumnFamily instead of BytesType - this comes up often in static Composite column families
