### PR TITLE
Added support for MultiGetSlice for Counter columns and super columns

### DIFF
--- a/src/Operations/MultiGetColumnFamilySlice.cs
+++ b/src/Operations/MultiGetColumnFamilySlice.cs
@@ -36,7 +36,9 @@ namespace FluentCassandra.Operations
 				var key = CassandraObject.GetCassandraObjectFromDatabaseByteArray(result.Key, schema.KeyValueType);
 
 				var r = new FluentColumnFamily(key, ColumnFamily.FamilyName, schema, result.Value.Select(col => {
-					return Helper.ConvertColumnToFluentColumn(col.Column, schema);
+                    if(col.Counter_column != null)
+					    return Helper.ConvertColumnToFluentCounterColumn(col.Counter_column, schema);
+                    return Helper.ConvertColumnToFluentColumn(col.Column, schema);
 				}));
 				ColumnFamily.Context.Attach(r);
 				r.MutationTracker.Clear();

--- a/src/Operations/MultiGetSuperColumnFamilySlice.cs
+++ b/src/Operations/MultiGetSuperColumnFamilySlice.cs
@@ -53,7 +53,12 @@ namespace FluentCassandra.Operations
 				}
 				else
 				{
-					superColumns = result.Value.Select(col => Helper.ConvertSuperColumnToFluentSuperColumn(col.Super_column, schema));
+					superColumns = result.Value.Select(col =>
+					    {
+					        if (col.Counter_super_column != null)
+					            return Helper.ConvertSuperColumnToFluentCounterSuperColumn(col.Counter_super_column, schema);
+                            return Helper.ConvertSuperColumnToFluentSuperColumn(col.Super_column, schema);
+                        });
 				}
 
 				var familyName = ColumnFamily.FamilyName;

--- a/test/FluentCassandra.Tests/CassandraDatabaseSetup.cs
+++ b/test/FluentCassandra.Tests/CassandraDatabaseSetup.cs
@@ -88,8 +88,8 @@ namespace FluentCassandra
 				keyspace.TryCreateColumnFamily<UUIDType>("StandardUUIDType");
                 keyspace.TryCreateColumnFamily(new CassandraColumnFamilySchema()
                     {
-                        FamilyName = "Counter", 
-                        ColumnNameType = CassandraType.UTF8Type, 
+                        FamilyName = "Counters", 
+                        ColumnNameType = CassandraType.AsciiType,
                         DefaultColumnValueType = CassandraType.CounterColumnType
                     });
 				keyspace.TryCreateColumnFamily(new CassandraColumnFamilySchema {
@@ -105,24 +105,24 @@ namespace FluentCassandra
 					ColumnNameType = CassandraType.DynamicCompositeType(new Dictionary<char, CassandraType> { { 'a', CassandraType.AsciiType }, { 'd', CassandraType.DoubleType } })
 				});
 
-				db.ExecuteNonQuery(@"
+                db.ExecuteNonQuery(@"
 CREATE COLUMNFAMILY Users (
 	Id int PRIMARY KEY,
 	Name ascii,
 	Email ascii,
 	Age int
 );");
-				db.ExecuteNonQuery(@"CREATE INDEX User_Age ON Users (Age);");
+                db.ExecuteNonQuery(@"CREATE INDEX User_Age ON Users (Age);");
 				db.Keyspace.ClearCachedKeyspaceSchema();
 
 				var family = db.GetColumnFamily<AsciiType>("Standard");
 				var superFamily = db.GetColumnFamily<AsciiType, AsciiType>("Super");
-				var userFamily = db.GetColumnFamily("Users");
-			    var counterFamily = db.GetColumnFamily("Counters");
+                var userFamily = db.GetColumnFamily("Users");
+			    var counterFamily = db.GetColumnFamily("Counter");
 
 				ResetFamily(family);
 				ResetSuperFamily(superFamily);
-				ResetUsersFamily(userFamily);
+                ResetUsersFamily(userFamily);
                 ResetCounterColumnFamily(counterFamily);
 			}
 		}

--- a/test/FluentCassandra.Tests/Operations/MultiGetSliceTest.cs
+++ b/test/FluentCassandra.Tests/Operations/MultiGetSliceTest.cs
@@ -10,6 +10,8 @@ namespace FluentCassandra.Operations
 	{
 		private CassandraContext _db;
 		private CassandraColumnFamily<AsciiType> _family;
+	    private CassandraColumnFamily _counterFamily;
+
 		private CassandraSuperColumnFamily<AsciiType, AsciiType> _superFamily;
 
 		public void SetFixture(CassandraDatabaseSetupFixture data)
@@ -18,6 +20,7 @@ namespace FluentCassandra.Operations
 			_db = setup.DB;
 			_family = setup.Family;
 			_superFamily = setup.SuperFamily;
+		    _counterFamily = setup.CounterFamily;
 		}
 
 		public void Dispose()
@@ -45,6 +48,22 @@ namespace FluentCassandra.Operations
 			// assert
 			Assert.Equal(expectedCount, columns.Count());
 		}
+
+        [Fact]
+        public void Counter_GetSlice_Columns()
+        {
+            // arrange
+            int expectedCount = 2;
+
+            // act
+            var columns = _counterFamily
+                .Get(new BytesType[] { _testKey, _testKey2 })
+                .FetchColumns(new AsciiType[] { "Test1", "Test2" })
+                .Execute();
+
+            // assert
+            Assert.Equal(expectedCount, columns.Count());
+        }
 
 		[Fact]
 		public void Super_GetSlice_Columns()


### PR DESCRIPTION
Added support for MultiGetSlice for Counter columns and super columns

Quick question though: I haven't been able to get any of the unit tests that connect to a live Cassandra instance to run due to errors with the CassandraDatabaseSetup.cs bootstrapper throwing errors - I think it has to do with the version of Cassandra running on my machine (DataStax Community Edition v1.1)

Could someone try running these and see if my new unit test  `Counter_GetSlice_Columns()` passes? I've been able to verify that the behavior works as expected inside my application now that I've made this change, but I don't like the fact that I can't get 80ish of the built-in unit tests to run on my system :(
