### PR TITLE
Fixed a bug with CassandraSlicePredicateQueryable (Count operations)

### DIFF
--- a/src/Operations/CassandraSlicePredicateQueryable.cs
+++ b/src/Operations/CassandraSlicePredicateQueryable.cs
@@ -121,6 +121,7 @@ namespace FluentCassandra
 
 			source = source.Family.CreateCassandraSlicePredicateQuery<TResult>(Expression.Call(null, ((MethodInfo)MethodBase.GetCurrentMethod()).MakeGenericMethod(new Type[] { typeof(TResult) }), new Expression[] { source.Expression }));
 			var op = (ColumnCount)source.BuildQueryableOperation();
+		    op.ColumnFamily = source.Family;
 			return source.Family.Context.ExecuteOperation(op);
 		}
 
@@ -131,6 +132,7 @@ namespace FluentCassandra
 
 			source = source.Family.CreateCassandraSlicePredicateQuery<TResult>(Expression.Call(null, ((MethodInfo)MethodBase.GetCurrentMethod()).MakeGenericMethod(new Type[] { typeof(TResult) }), new Expression[] { source.Expression }));
 			var op = (MultiGetColumnCount)source.BuildQueryableOperation();
+		    op.ColumnFamily = source.Family;
 			return source.Family.Context.ExecuteOperation(op);
 		}
 

--- a/src/Types/CassandraObjectConverter.cs
+++ b/src/Types/CassandraObjectConverter.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 
 namespace FluentCassandra.Types
 {
-	internal abstract class CassandraObjectConverter<T>
+    public abstract class CassandraObjectConverter<T>
 	{
 		public abstract bool CanConvertFrom(Type sourceType);
 


### PR DESCRIPTION
Fixed a null reference bug with CassandraSlicePredicateQueryable queries.

If you run a query like the one below using FluentCassandra 1.2.1

```
var userSessions =
userSessionsCf.Get(rowKey)
.StartWithColumn(start.Ticks)
.TakeUntilColumn(start.AddDays(1).Ticks - 1)
 CountColumns();
```

You will receive an error thrown upon execution of the request due to the CountColumn operation's ColumnFamily field being null. 

This patch addresses that and causes this query to work as expected.
