### PR TITLE
Suggested fix for Issue #105

### DIFF
--- a/src/Operations/CassandraSlicePredicateQueryable.cs
+++ b/src/Operations/CassandraSlicePredicateQueryable.cs
@@ -121,6 +121,7 @@ namespace FluentCassandra
 
 			source = source.Family.CreateCassandraSlicePredicateQuery<TResult>(Expression.Call(null, ((MethodInfo)MethodBase.GetCurrentMethod()).MakeGenericMethod(new Type[] { typeof(TResult) }), new Expression[] { source.Expression }));
 			var op = (ColumnCount)source.BuildQueryableOperation();
+		    op.ColumnFamily = source.Family;
 			return source.Family.Context.ExecuteOperation(op);
 		}
 
@@ -131,6 +132,7 @@ namespace FluentCassandra
 
 			source = source.Family.CreateCassandraSlicePredicateQuery<TResult>(Expression.Call(null, ((MethodInfo)MethodBase.GetCurrentMethod()).MakeGenericMethod(new Type[] { typeof(TResult) }), new Expression[] { source.Expression }));
 			var op = (MultiGetColumnCount)source.BuildQueryableOperation();
+		    op.ColumnFamily = source.Family;
 			return source.Family.Context.ExecuteOperation(op);
 		}
 

--- a/src/Types/CassandraObjectConverter.cs
+++ b/src/Types/CassandraObjectConverter.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 
 namespace FluentCassandra.Types
 {
-	internal abstract class CassandraObjectConverter<T>
+    public abstract class CassandraObjectConverter<T>
 	{
 		public abstract bool CanConvertFrom(Type sourceType);
 

--- a/src/Types/CassandraObjectConverter.cs
+++ b/src/Types/CassandraObjectConverter.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 
 namespace FluentCassandra.Types
 {
-    public abstract class CassandraObjectConverter<T>
+    internal abstract class CassandraObjectConverter<T>
 	{
 		public abstract bool CanConvertFrom(Type sourceType);
 

--- a/src/Types/CompositeType.cs
+++ b/src/Types/CompositeType.cs
@@ -135,7 +135,16 @@ namespace FluentCassandra.Types
 
 		public override int GetHashCode()
 		{
-			return _value.GetHashCode();
+			//Compute a hash from the sum of the parts
+			unchecked
+			{
+				int hash = 17;
+				foreach (var keyPart in _value)
+				{
+					hash = hash*23 + keyPart.GetHashCode();
+				}
+				return hash;
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
I decided to run an experiment and see if changing the `CompositeType.GetHashCode` function would alleviate the issue I described in issue #105

The unit test I attached to issue #105 now passes as a result of the changes made. I followed [Jon Skeet's advice on generating safe hash functions for multiple objects in C#](http://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-an-overridden-system-object-gethashcode) - what do you think?

P.S. sorry for the noise on this PR - had some trouble figuring out how to squash some commits from my previous PR.
