### PR TITLE
Alternate TSocket Impl to add connect timeout

### DIFF
--- a/src/Connections/Connection.cs
+++ b/src/Connections/Connection.cs
@@ -46,7 +46,7 @@ namespace FluentCassandra.Connections
 		/// </summary>
 		private void InitTransportAndClient()
 		{
-			var socket = new TSocket(Server.Host, Server.Port, Server.Timeout * 1000);
+            var socket = new TSocketWithConnectTimeout(Server.Host, Server.Port, Server.Timeout * 1000);
 
 			switch (ConnectionType)
 			{

--- a/src/Connections/TSocketWithConnectTimeout.cs
+++ b/src/Connections/TSocketWithConnectTimeout.cs
@@ -1,0 +1,141 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+using System;
+using System.Net.Sockets;
+using FluentCassandra.Thrift.Transport;
+
+namespace FluentCassandra.Connections {
+
+    /// <summary>
+    /// Custom implementation of TStreamTransport, mimicking TSocket while adding connection timeout. 
+    /// </summary>
+    public class TSocketWithConnectTimeout : TStreamTransport
+    {
+        private TcpClient client = null;
+        private readonly string host = null;
+        private readonly int port = 0;
+        private readonly int timeout = 0;
+
+        public TSocketWithConnectTimeout(string host, int port, int timeout)
+        {
+            this.host = host;
+            this.port = port;
+            this.timeout = timeout;
+
+            InitSocket();
+        }
+
+        private void InitSocket()
+        {
+            client = new TcpClient();
+            client.ReceiveTimeout = client.SendTimeout = timeout;
+            client.Client.NoDelay = true;
+        }
+
+        public override bool IsOpen
+        {
+            get
+            {
+                if(client == null)
+                {
+                    return false;
+                }
+
+                return client.Connected;
+            }
+        }
+
+        public override void Open()
+        {
+            if(IsOpen)
+            {
+                throw new TTransportException(TTransportException.ExceptionType.AlreadyOpen, "Socket already connected");
+            }
+
+            if(String.IsNullOrEmpty(host))
+            {
+                throw new TTransportException(TTransportException.ExceptionType.NotOpen, "Cannot open null host");
+            }
+
+            if(port <= 0)
+            {
+                throw new TTransportException(TTransportException.ExceptionType.NotOpen, "Cannot open without port");
+            }
+
+            if(client == null)
+            {
+                InitSocket();
+            }
+
+            var connectTimeout = timeout;
+            if(connectTimeout == 0)
+            {
+                connectTimeout = -1;
+            }
+            else if(connectTimeout > 0 && connectTimeout < 500)
+            {
+                connectTimeout = 500;
+            }
+
+            var ar = client.BeginConnect(host, port, null, null);
+            if(ar.AsyncWaitHandle.WaitOne(connectTimeout)) {
+                client.EndConnect(ar);
+            } else {
+                client.Close();
+                throw new TimeoutException();
+            }
+            inputStream = client.GetStream();
+            outputStream = client.GetStream();
+        }
+
+        public override void Close()
+        {
+            base.Close();
+            if(client != null)
+            {
+                client.Close();
+                client = null;
+            }
+        }
+
+        #region " IDisposable Support "
+        private bool _IsDisposed;
+
+        // IDisposable
+        protected override void Dispose(bool disposing)
+        {
+            if(!_IsDisposed) 
+            {
+                if(disposing)
+                {
+                    if(client != null)
+                        ((IDisposable)client).Dispose();
+                    base.Dispose(disposing);
+                }
+            }
+            _IsDisposed = true;
+        }
+        #endregion
+    }
+}

--- a/src/FluentCassandra.csproj
+++ b/src/FluentCassandra.csproj
@@ -104,6 +104,7 @@
     <Compile Include="CassandraSuperColumnFamily.cs" />
     <Compile Include="CassandraTokenRange.cs" />
     <Compile Include="Connections\CassandraConnectionException.cs" />
+    <Compile Include="Connections\TSocketWithConnectTimeout.cs" />
     <Compile Include="Connections\Connection.cs" />
     <Compile Include="Connections\ConnectionBuilder.cs" />
     <Compile Include="Connections\ConnectionProvider.cs" />


### PR DESCRIPTION
While Cassandra Connection has a timeout parameter, it is only used to Send and Receive Timeouts by TSocket.

This change creates an alternate TStreamTransport implemenation that mimick TSocket, except that it uses Begin/EndConnect in Open() to use the timeout value for connect as well.
