### PR TITLE
Super counter column support + unit tests + unit test bug fixes

### DIFF
--- a/src/CassandraColumnFamilyOperations.cs
+++ b/src/CassandraColumnFamilyOperations.cs
@@ -62,6 +62,14 @@ namespace FluentCassandra
 			family.ExecuteOperation(op);
 		}
 
+        public static void InsertCounterColumn(this CassandraColumnFamily family, CassandraObject key,
+                                               CassandraObject superColumnName, CassandraObject columnName,
+                                               long columnValue)
+        {
+            var op = new AddColumn(key, superColumnName, columnName, columnValue);
+            family.ExecuteOperation(op);
+        }
+
 		#endregion
 
 		#region GetColumn

--- a/test/FluentCassandra.Integration.Tests/CassandraDatabaseSetup.cs
+++ b/test/FluentCassandra.Integration.Tests/CassandraDatabaseSetup.cs
@@ -17,6 +17,7 @@ namespace FluentCassandra.Integration.Tests
 
 		public CassandraColumnFamily UserFamily;
 		public CassandraColumnFamily CounterFamily;
+		public CassandraSuperColumnFamily SuperCounterFamily;
 
 		public User[] Users = new[] {
 					new User { Id = 1, Name = "Darren Gemmell", Email = "darren@somewhere.com", Age = 32 },
@@ -54,6 +55,7 @@ namespace FluentCassandra.Integration.Tests
 			SuperFamily = DB.GetColumnFamily<AsciiType, AsciiType>("Super");
 			UserFamily = DB.GetColumnFamily("Users");
 			CounterFamily = DB.GetColumnFamily("Counters");
+			SuperCounterFamily = DB.GetSuperColumnFamily("SuperCounters");
 
 			if (exists && !reset)
 				return;
@@ -90,6 +92,13 @@ namespace FluentCassandra.Integration.Tests
 					ColumnNameType = CassandraType.AsciiType,
 					DefaultColumnValueType = CassandraType.CounterColumnType
 				});
+				keyspace.TryCreateColumnFamily(new CassandraColumnFamilySchema()
+					{
+						FamilyName = "SuperCounters",
+						SuperColumnNameType = CassandraType.AsciiType,
+						ColumnNameType = CassandraType.AsciiType,
+						DefaultColumnValueType = CassandraType.CounterColumnType
+					});
 				keyspace.TryCreateColumnFamily(new CassandraColumnFamilySchema {
 					FamilyName = "StandardDecimalType",
 					ColumnNameType = CassandraType.DecimalType

--- a/test/FluentCassandra.Integration.Tests/CassandraDatabaseSetup.cs
+++ b/test/FluentCassandra.Integration.Tests/CassandraDatabaseSetup.cs
@@ -92,7 +92,7 @@ namespace FluentCassandra.Integration.Tests
 					ColumnNameType = CassandraType.AsciiType,
 					DefaultColumnValueType = CassandraType.CounterColumnType
 				});
-				keyspace.TryCreateColumnFamily(new CassandraColumnFamilySchema()
+				keyspace.TryCreateColumnFamily(new CassandraColumnFamilySchema(type:ColumnType.Super)
 					{
 						FamilyName = "SuperCounters",
 						SuperColumnNameType = CassandraType.AsciiType,

--- a/test/FluentCassandra.Integration.Tests/FluentCassandra.Integration.Tests.csproj
+++ b/test/FluentCassandra.Integration.Tests/FluentCassandra.Integration.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Operations\GetRangeSliceTest.cs" />
     <Compile Include="Operations\GetSliceTest.cs" />
     <Compile Include="Operations\InsertColumnTest.cs" />
+    <Compile Include="Operations\InsertCounterColumnTest.cs" />
     <Compile Include="Operations\MultiGetSliceTest.cs" />
     <Compile Include="Operations\RemoveColumnTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/test/FluentCassandra.Integration.Tests/Operations/InsertColumnTest.cs
+++ b/test/FluentCassandra.Integration.Tests/Operations/InsertColumnTest.cs
@@ -57,12 +57,13 @@ namespace FluentCassandra.Integration.Tests.Operations
 
 			// act
 			_superFamily.InsertColumn(_testKey, _testSuperName, _testName, value, timestamp, timeToLive);
-			var column = _family.Get(_testKey).Execute();
+			var column = _superFamily.Get(_testKey).Execute();
 			var actual = column.FirstOrDefault().Columns.FirstOrDefault();
 
 			// assert
-			Assert.Equal(_testName, (string)actual.ColumnName);
-			Assert.Equal(value, (double)actual.ColumnValue);
+			Assert.Equal(_testSuperName, (string)actual.ColumnName);
+			Assert.Equal(_testName, (string)actual.Columns[0].ColumnName);
+			Assert.Equal(value, (double)actual.Columns[0].ColumnValue);
 		}
 	}
 }

--- a/test/FluentCassandra.Integration.Tests/Operations/InsertCounterColumnTest.cs
+++ b/test/FluentCassandra.Integration.Tests/Operations/InsertCounterColumnTest.cs
@@ -12,12 +12,6 @@ namespace FluentCassandra.Integration.Tests.Operations
         private CassandraColumnFamily _counterFamily;
         private CassandraSuperColumnFamily _superCounterFamily;
 
-        public InsertCounterColumnTest()
-        {
-            //Create a new row each time we run the test, so the expected counter values are always equal to 1
-            _testKey = Guid.NewGuid().ToString(); 
-        }
-
         public void SetFixture(CassandraDatabaseSetupFixture data)
         {
             var setup = data.DatabaseSetup();
@@ -31,7 +25,7 @@ namespace FluentCassandra.Integration.Tests.Operations
             _db.Dispose();
         }
 
-        private readonly string _testKey;
+        private const string _testKey = "CounterTest1";
         private const string _testName = "Test1";
         private const string _testSuperName = "SubTest1";
 

--- a/test/FluentCassandra.Integration.Tests/Operations/InsertCounterColumnTest.cs
+++ b/test/FluentCassandra.Integration.Tests/Operations/InsertCounterColumnTest.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using FluentCassandra.Types;
+using Xunit;
+
+
+namespace FluentCassandra.Integration.Tests.Operations
+{
+    public class InsertCounterColumnTest : IUseFixture<CassandraDatabaseSetupFixture>, IDisposable
+    {
+        private CassandraContext _db;
+        private CassandraColumnFamily _counterFamily;
+        private CassandraSuperColumnFamily _superCounterFamily;
+
+        public InsertCounterColumnTest()
+        {
+            //Create a new row each time we run the test, so the expected counter values are always equal to 1
+            _testKey = Guid.NewGuid().ToString(); 
+        }
+
+        public void SetFixture(CassandraDatabaseSetupFixture data)
+        {
+            var setup = data.DatabaseSetup();
+            _db = setup.DB;
+            _counterFamily = setup.CounterFamily;
+            _superCounterFamily = setup.SuperCounterFamily;
+        }
+
+        public void Dispose()
+        {
+            _db.Dispose();
+        }
+
+        private readonly string _testKey;
+        private const string _testName = "Test1";
+        private const string _testSuperName = "SubTest1";
+
+        [Fact]
+        public void CounterColumnFamily()
+        {
+            //arrange
+            long value = 1L;
+
+            //act
+            _counterFamily.InsertCounterColumn(_testKey, _testName, value);
+            var column = _counterFamily.Get(_testKey).Execute();
+            var actual = column.FirstOrDefault().Columns.FirstOrDefault();
+
+            // assert
+            Assert.Equal(_testName, (string)actual.ColumnName);
+            Assert.Equal(value, (double)actual.ColumnValue);
+        }
+
+        [Fact]
+        public void SuperCounterColumnFamily()
+        {
+            //arrange
+            long value = 1L;
+
+            //act
+            _superCounterFamily.InsertCounterColumn(_testKey, _testSuperName, _testName, value);
+            var column = _superCounterFamily.Get(_testKey).Execute();
+            var actual = column.FirstOrDefault().Columns.FirstOrDefault();
+
+            // assert
+            Assert.Equal(_testSuperName, (string)actual.ColumnName);
+            Assert.Equal(_testName, (string)actual.Columns[0].ColumnName);
+            Assert.Equal(value, (double)actual.Columns[0].ColumnValue);
+        }
+    }
+}


### PR DESCRIPTION
Changes in this pull request:
- Added an overload to `InsertCounterColumn` which accepts a SuperCounterColumn as an argument
- Added a new test fixture to **FluentCassandra.Integration.Tests** which tests `InsertCounterColumn` for regular counter column families as well as super counter column families.
- Fixed a bug with `InsertColumn` tests - the SuperCounterColumn test wasn't actually reading its results from the super counter column family, and only passed because the data stored in the regular column family it was reading from just happened to share the same expected values.
- Modified the test fixture setup such that it adds a new `SuperCounter` family to the Testing keyspace.
