### PR TITLE
Fixing Single server manager so that failure does not cause a reconnect spin-loop

### DIFF
--- a/src/Connections/InfallibleSingleServerManager.cs
+++ b/src/Connections/InfallibleSingleServerManager.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace FluentCassandra.Connections
+{
+	public class InfallibleSingleServerManager : IServerManager
+	{
+		private Server _server;
+
+        public InfallibleSingleServerManager(IConnectionBuilder builder)
+		{
+			_server = builder.Servers[0]; 
+		}
+
+		#region IServerManager Members
+
+		public bool HasNext
+		{
+			get { return true; }
+		}
+
+		public Server Next()
+		{
+			return _server;
+		}
+
+		public void ErrorOccurred(Server server, Exception exc = null)
+		{
+			Debug.WriteLineIf(exc != null, exc, "connection");
+		}
+
+		public void Add(Server server)
+		{
+			_server = server;
+		}
+
+		public void Remove(Server server)
+		{
+			throw new NotSupportedException("You cannot remove a server since SingleServerManager supports one server. Call the Add method to change the server.");
+		}
+
+		#endregion
+		
+		#region IEnumerable<Server> Members
+		
+		public IEnumerator<Server> GetEnumerator()
+		{
+			throw new NotImplementedException("SingleServerManager does not implement Enumerable(server)");
+		}
+		
+		#endregion
+		
+		#region IEnumerable Members
+		
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+		
+		#endregion
+
+	}
+}

--- a/src/Connections/InfallibleSingleServerManager.cs
+++ b/src/Connections/InfallibleSingleServerManager.cs
@@ -8,7 +8,7 @@ namespace FluentCassandra.Connections
 	{
 		private Server _server;
 
-        public InfallibleSingleServerManager(IConnectionBuilder builder)
+		public InfallibleSingleServerManager(IConnectionBuilder builder)
 		{
 			_server = builder.Servers[0]; 
 		}

--- a/src/Connections/ServerManagerFactory.cs
+++ b/src/Connections/ServerManagerFactory.cs
@@ -3,46 +3,46 @@ using System.Collections.Generic;
 
 namespace FluentCassandra.Connections
 {
-    public static class ServerManagerFactory
-    {
-        private static readonly object LOCK = new object();
-        private static volatile IDictionary<string, IServerManager> _managers = new Dictionary<string, IServerManager>();
-        private static volatile Func<IConnectionBuilder, IServerManager> _alternateManagerCreator;
+	public static class ServerManagerFactory
+	{
+		private static readonly object LOCK = new object();
+		private static volatile IDictionary<string, IServerManager> _managers = new Dictionary<string, IServerManager>();
+		private static volatile Func<IConnectionBuilder, IServerManager> _alternateManagerCreator;
 
-        public static IServerManager Get(IConnectionBuilder connectionBuilder)
-        {
-            lock(LOCK)
-            {
-                IServerManager manager;
+		public static IServerManager Get(IConnectionBuilder connectionBuilder)
+		{
+			lock(LOCK)
+			{
+				IServerManager manager;
 
-                if(!_managers.TryGetValue(connectionBuilder.Uuid, out manager))
-                {
-                    manager = CreateManager(connectionBuilder);
-                    _managers.Add(connectionBuilder.Uuid, manager);
-                }
+				if(!_managers.TryGetValue(connectionBuilder.Uuid, out manager))
+				{
+					manager = CreateManager(connectionBuilder);
+					_managers.Add(connectionBuilder.Uuid, manager);
+				}
 
-                return manager;
-            }
-        }
+				return manager;
+			}
+		}
 
-        public static void SetAlternateManagerCreationCallback(Func<IConnectionBuilder, IServerManager> alternateManagerCreator)
-        {
-            lock(LOCK)
-                _alternateManagerCreator = alternateManagerCreator;
-        }
+		public static void SetAlternateManagerCreationCallback(Func<IConnectionBuilder, IServerManager> alternateManagerCreator)
+		{
+			lock(LOCK)
+				_alternateManagerCreator = alternateManagerCreator;
+		}
 
-        private static IServerManager CreateManager(IConnectionBuilder builder) 
-        {
-            if(_alternateManagerCreator != null) 
-            {
-                var manager = _alternateManagerCreator(builder);
-                if(manager != null)
-                    return manager;
-            }
+		private static IServerManager CreateManager(IConnectionBuilder builder) 
+		{
+			if(_alternateManagerCreator != null) 
+			{
+				var manager = _alternateManagerCreator(builder);
+				if(manager != null)
+					return manager;
+			}
 
-            return builder.Servers.Count == 1 
-                ? (IServerManager)new SingleServerManager(builder) 
-                : new RoundRobinServerManager(builder);
-        }
-    }
+			return builder.Servers.Count == 1 
+				? (IServerManager)new SingleServerManager(builder) 
+				: new RoundRobinServerManager(builder);
+		}
+	}
 }

--- a/src/Connections/ServerManagerFactory.cs
+++ b/src/Connections/ServerManagerFactory.cs
@@ -1,33 +1,48 @@
+using System;
 using System.Collections.Generic;
 
 namespace FluentCassandra.Connections
 {
-	public static class ServerManagerFactory
-	{
-		private static readonly object Lock = new object();
-		private static volatile IDictionary<string, IServerManager> Managers = new Dictionary<string, IServerManager>();
+    public static class ServerManagerFactory
+    {
+        private static readonly object LOCK = new object();
+        private static volatile IDictionary<string, IServerManager> _managers = new Dictionary<string, IServerManager>();
+        private static volatile Func<IConnectionBuilder, IServerManager> _alternateManagerCreator;
 
-		public static IServerManager Get(IConnectionBuilder connectionBuilder)
-		{
-			lock (Lock) {
-				IServerManager manager;
-			
-				if (!Managers.TryGetValue(connectionBuilder.Uuid, out manager)) {
-					manager = CreateManager(connectionBuilder);
-					Managers.Add(connectionBuilder.Uuid, manager);
-				}
+        public static IServerManager Get(IConnectionBuilder connectionBuilder)
+        {
+            lock(LOCK)
+            {
+                IServerManager manager;
 
-				return manager;
-			}
-		}
+                if(!_managers.TryGetValue(connectionBuilder.Uuid, out manager))
+                {
+                    manager = CreateManager(connectionBuilder);
+                    _managers.Add(connectionBuilder.Uuid, manager);
+                }
 
-		private static IServerManager CreateManager(IConnectionBuilder builder)
-		{
-			if (builder.Servers.Count == 1) {
-				return new SingleServerManager(builder);
-			} else {
-				return new RoundRobinServerManager(builder);
-			}
-		}
-	}
+                return manager;
+            }
+        }
+
+        public static void SetAlternateManagerCreationCallback(Func<IConnectionBuilder, IServerManager> alternateManagerCreator)
+        {
+            lock(LOCK)
+                _alternateManagerCreator = alternateManagerCreator;
+        }
+
+        private static IServerManager CreateManager(IConnectionBuilder builder) 
+        {
+            if(_alternateManagerCreator != null) 
+            {
+                var manager = _alternateManagerCreator(builder);
+                if(manager != null)
+                    return manager;
+            }
+
+            return builder.Servers.Count == 1 
+                ? (IServerManager)new SingleServerManager(builder) 
+                : new RoundRobinServerManager(builder);
+        }
+    }
 }

--- a/src/Connections/SingleServerManager.cs
+++ b/src/Connections/SingleServerManager.cs
@@ -8,42 +8,42 @@ namespace FluentCassandra.Connections
 	public class SingleServerManager : IServerManager
 	{
 		private readonly object _lock = new object();
-        private readonly Timer _recoveryTimer;
-        private readonly long _recoveryTimerInterval;
-        private Server _server;
-	    private bool _failed;
+		private readonly Timer _recoveryTimer;
+		private readonly long _recoveryTimerInterval;
+		private Server _server;
+		private bool _failed;
 
 
 		public SingleServerManager(IConnectionBuilder builder)
 		{
 			_server = builder.Servers[0];
-            _recoveryTimerInterval = (long)builder.ServerPollingInterval.TotalMilliseconds;
-            _recoveryTimer = new Timer(ServerRecover);
-        }
+			_recoveryTimerInterval = (long)builder.ServerPollingInterval.TotalMilliseconds;
+			_recoveryTimer = new Timer(ServerRecover);
+		}
 
-	    private void ServerRecover(object unused)
-        {
-            lock(_lock)
-            {
-                if(!_failed)
-                    return;
+		private void ServerRecover(object unused)
+		{
+			lock(_lock)
+			{
+				if(!_failed)
+					return;
 
-                var connection = new Connection(_server, ConnectionType.Simple, 1024);
+				var connection = new Connection(_server, ConnectionType.Simple, 1024);
 
-                try
-                {
-                    connection.Open();
-                    _failed = false;
-                }
-                catch { }
-                finally
-                {
-                    connection.Close();
-                }
-            }
-	    }
+				try
+				{
+					connection.Open();
+					_failed = false;
+				}
+				catch { }
+				finally
+				{
+					connection.Close();
+				}
+			}
+		}
 
-	    #region IServerManager Members
+		#region IServerManager Members
 
 		public bool HasNext
 		{
@@ -56,27 +56,27 @@ namespace FluentCassandra.Connections
 		}
 
 		public void ErrorOccurred(Server server, Exception exc = null)
-        {
+		{
 			Debug.WriteLineIf(exc != null, exc, "connection");
-            lock(_lock)
-            {
-                if(_failed)
-                    return;
+			lock(_lock)
+			{
+				if(_failed)
+					return;
 
-                _failed = true;
-                _recoveryTimer.Change(_recoveryTimerInterval, Timeout.Infinite);
-            }
-        }
+				_failed = true;
+				_recoveryTimer.Change(_recoveryTimerInterval, Timeout.Infinite);
+			}
+		}
 
 		public void Add(Server server)
 		{
-            lock(_lock)
-            {
-			    _server = server;
-		        _failed = false;
-                _recoveryTimer.Change(Timeout.Infinite,Timeout.Infinite);
-            }
-        }
+			lock(_lock)
+			{
+				_server = server;
+				_failed = false;
+				_recoveryTimer.Change(Timeout.Infinite,Timeout.Infinite);
+			}
+		}
 
 		public void Remove(Server server)
 		{

--- a/src/Connections/SingleServerManager.cs
+++ b/src/Connections/SingleServerManager.cs
@@ -1,40 +1,82 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 
 namespace FluentCassandra.Connections
 {
 	public class SingleServerManager : IServerManager
 	{
 		private readonly object _lock = new object();
-		private Server _server;
+        private readonly Timer _recoveryTimer;
+        private readonly long _recoveryTimerInterval;
+        private Server _server;
+	    private bool _failed;
+
 
 		public SingleServerManager(IConnectionBuilder builder)
 		{
-			_server = builder.Servers[0]; 
-		}
+			_server = builder.Servers[0];
+            _recoveryTimerInterval = (long)builder.ServerPollingInterval.TotalMilliseconds;
+            _recoveryTimer = new Timer(ServerRecover);
+        }
 
-		#region IServerManager Members
+	    private void ServerRecover(object unused)
+        {
+            lock(_lock)
+            {
+                if(!_failed)
+                    return;
+
+                var connection = new Connection(_server, ConnectionType.Simple, 1024);
+
+                try
+                {
+                    connection.Open();
+                    _failed = false;
+                }
+                catch { }
+                finally
+                {
+                    connection.Close();
+                }
+            }
+	    }
+
+	    #region IServerManager Members
 
 		public bool HasNext
 		{
-			get { return true; }
+			get { return !_failed; }
 		}
 
 		public Server Next()
 		{
-			return _server;
+			return _failed ? null : _server;
 		}
 
 		public void ErrorOccurred(Server server, Exception exc = null)
-		{
+        {
 			Debug.WriteLineIf(exc != null, exc, "connection");
-		}
+            lock(_lock)
+            {
+                if(_failed)
+                    return;
+
+                _failed = true;
+                _recoveryTimer.Change(_recoveryTimerInterval, Timeout.Infinite);
+            }
+        }
 
 		public void Add(Server server)
 		{
-			_server = server;
-		}
+            lock(_lock)
+            {
+			    _server = server;
+		        _failed = false;
+                _recoveryTimer.Change(Timeout.Infinite,Timeout.Infinite);
+            }
+        }
 
 		public void Remove(Server server)
 		{

--- a/src/FluentCassandra.csproj
+++ b/src/FluentCassandra.csproj
@@ -108,6 +108,7 @@
     <Compile Include="CassandraTokenRange.cs" />
     <Compile Include="Connections\CassandraConnectionException.cs" />
     <Compile Include="Connections\LockTimeoutException.cs" />
+    <Compile Include="Connections\InfallibleSingleServerManager.cs" />
     <Compile Include="Connections\TSocketWithConnectTimeout.cs" />
     <Compile Include="Connections\Connection.cs" />
     <Compile Include="Connections\ConnectionBuilder.cs" />

--- a/test/FluentCassandra.Tests/Connections/InfallibleSingleServerManagerTests.cs
+++ b/test/FluentCassandra.Tests/Connections/InfallibleSingleServerManagerTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Xunit;
+
+namespace FluentCassandra.Connections
+{
+    public class InfallibleSingleServerManagerTests
+	{
+		[Fact]
+		public void CanGetServerAfterError()
+		{
+			var target = new InfallibleSingleServerManager(new ConnectionBuilder("Server=unit-test-1"));
+
+			var original = target.Next();
+
+			for (int i = 0; i < 10; i++)
+			{
+                Assert.True(target.HasNext, "InfallibleSingleServerManager should always have another server available.");
+				
+				Server next = target.Next();
+                Assert.True(original.ToString().Equals(next.ToString(), StringComparison.OrdinalIgnoreCase), "InfallibleSingleServerManager always returns the same server.");
+
+				//mark the server as failing to set up the next test iteration.
+				target.ErrorOccurred(next);
+			}
+		}
+	}
+}

--- a/test/FluentCassandra.Tests/Connections/InfallibleSingleServerManagerTests.cs
+++ b/test/FluentCassandra.Tests/Connections/InfallibleSingleServerManagerTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace FluentCassandra.Connections
 {
-    public class InfallibleSingleServerManagerTests
+	public class InfallibleSingleServerManagerTests
 	{
 		[Fact]
 		public void CanGetServerAfterError()
@@ -14,10 +14,10 @@ namespace FluentCassandra.Connections
 
 			for (int i = 0; i < 10; i++)
 			{
-                Assert.True(target.HasNext, "InfallibleSingleServerManager should always have another server available.");
+				Assert.True(target.HasNext, "InfallibleSingleServerManager should always have another server available.");
 				
 				Server next = target.Next();
-                Assert.True(original.ToString().Equals(next.ToString(), StringComparison.OrdinalIgnoreCase), "InfallibleSingleServerManager always returns the same server.");
+				Assert.True(original.ToString().Equals(next.ToString(), StringComparison.OrdinalIgnoreCase), "InfallibleSingleServerManager always returns the same server.");
 
 				//mark the server as failing to set up the next test iteration.
 				target.ErrorOccurred(next);

--- a/test/FluentCassandra.Tests/Connections/ServerManagerFactoryTests.cs
+++ b/test/FluentCassandra.Tests/Connections/ServerManagerFactoryTests.cs
@@ -5,88 +5,88 @@ using Xunit;
 
 namespace FluentCassandra.Connections 
 {
-    public class ServerManagerFactoryTests 
-    {
+	public class ServerManagerFactoryTests 
+	{
 
-        // Make sure these tests never run in parallel (in case someone uses a parallel test runner),
-        // since they both manipulate global state of a singleton
-        private static readonly object _lock = new object();
+		// Make sure these tests never run in parallel (in case someone uses a parallel test runner),
+		// since they both manipulate global state of a singleton
+		private static readonly object _lock = new object();
 
-        [Fact]
-        public void Can_insert_a_server_manager_creator() 
-        {
-            lock(_lock) 
-            {
-                try 
-                {
-                    ServerManagerFactory.SetAlternateManagerCreationCallback(b => new StubServerManager());
-                    var manager = ServerManagerFactory.Get(new ConnectionBuilder("Server=unit-test-1111"));
+		[Fact]
+		public void Can_insert_a_server_manager_creator() 
+		{
+			lock(_lock) 
+			{
+				try 
+				{
+					ServerManagerFactory.SetAlternateManagerCreationCallback(b => new StubServerManager());
+					var manager = ServerManagerFactory.Get(new ConnectionBuilder("Server=unit-test-1111"));
 
-                    Assert.IsType<StubServerManager>(manager);
-                } 
-                finally 
-                {
-                    ServerManagerFactory.SetAlternateManagerCreationCallback(null);
-                }
-            }
-        }
+					Assert.IsType<StubServerManager>(manager);
+				} 
+				finally 
+				{
+					ServerManagerFactory.SetAlternateManagerCreationCallback(null);
+				}
+			}
+		}
 
-        [Fact]
-        public void Manager_creator_can_be_optional() 
-        {
-            lock(_lock) 
-            {
-                try
-                {
-                    ServerManagerFactory.SetAlternateManagerCreationCallback(
-                        b => b.Servers[0].Host == "unit-test-2222b" ? new StubServerManager() : null
-                    );
-                    var manager1 = ServerManagerFactory.Get(new ConnectionBuilder("Server=unit-test-2222a"));
-                    var manager2 = ServerManagerFactory.Get(new ConnectionBuilder("Server=unit-test-2222b"));
+		[Fact]
+		public void Manager_creator_can_be_optional() 
+		{
+			lock(_lock) 
+			{
+				try
+				{
+					ServerManagerFactory.SetAlternateManagerCreationCallback(
+						b => b.Servers[0].Host == "unit-test-2222b" ? new StubServerManager() : null
+					);
+					var manager1 = ServerManagerFactory.Get(new ConnectionBuilder("Server=unit-test-2222a"));
+					var manager2 = ServerManagerFactory.Get(new ConnectionBuilder("Server=unit-test-2222b"));
 
-                    Assert.IsType<SingleServerManager>(manager1);
-                    Assert.IsType<StubServerManager>(manager2);
-                }
-                finally 
-                {
-                    ServerManagerFactory.SetAlternateManagerCreationCallback(null);
-                }
-            }
-        }
+					Assert.IsType<SingleServerManager>(manager1);
+					Assert.IsType<StubServerManager>(manager2);
+				}
+				finally 
+				{
+					ServerManagerFactory.SetAlternateManagerCreationCallback(null);
+				}
+			}
+		}
 
-        public class StubServerManager : IServerManager 
-        {
-            public IEnumerator<Server> GetEnumerator() 
-            {
-                throw new NotImplementedException();
-            }
+		public class StubServerManager : IServerManager 
+		{
+			public IEnumerator<Server> GetEnumerator() 
+			{
+				throw new NotImplementedException();
+			}
 
-            IEnumerator IEnumerable.GetEnumerator() 
-            {
-                return GetEnumerator();
-            }
+			IEnumerator IEnumerable.GetEnumerator() 
+			{
+				return GetEnumerator();
+			}
 
-            public bool HasNext { get; private set; }
-            
-            public Server Next() 
-            {
-                throw new NotImplementedException();
-            }
+			public bool HasNext { get; private set; }
+			
+			public Server Next() 
+			{
+				throw new NotImplementedException();
+			}
 
-            public void ErrorOccurred(Server server, Exception exc = null) 
-            {
-                throw new NotImplementedException();
-            }
+			public void ErrorOccurred(Server server, Exception exc = null) 
+			{
+				throw new NotImplementedException();
+			}
 
-            public void Add(Server server) 
-            {
-                throw new NotImplementedException();
-            }
+			public void Add(Server server) 
+			{
+				throw new NotImplementedException();
+			}
 
-            public void Remove(Server server) 
-            {
-                throw new NotImplementedException();
-            }
-        }
-    }
+			public void Remove(Server server) 
+			{
+				throw new NotImplementedException();
+			}
+		}
+	}
 }

--- a/test/FluentCassandra.Tests/Connections/ServerManagerFactoryTests.cs
+++ b/test/FluentCassandra.Tests/Connections/ServerManagerFactoryTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FluentCassandra.Connections 
+{
+    public class ServerManagerFactoryTests 
+    {
+
+        // Make sure these tests never run in parallel (in case someone uses a parallel test runner),
+        // since they both manipulate global state of a singleton
+        private static readonly object _lock = new object();
+
+        [Fact]
+        public void Can_insert_a_server_manager_creator() 
+        {
+            lock(_lock) 
+            {
+                try 
+                {
+                    ServerManagerFactory.SetAlternateManagerCreationCallback(b => new StubServerManager());
+                    var manager = ServerManagerFactory.Get(new ConnectionBuilder("Server=unit-test-1111"));
+
+                    Assert.IsType<StubServerManager>(manager);
+                } 
+                finally 
+                {
+                    ServerManagerFactory.SetAlternateManagerCreationCallback(null);
+                }
+            }
+        }
+
+        [Fact]
+        public void Manager_creator_can_be_optional() 
+        {
+            lock(_lock) 
+            {
+                try
+                {
+                    ServerManagerFactory.SetAlternateManagerCreationCallback(
+                        b => b.Servers[0].Host == "unit-test-2222b" ? new StubServerManager() : null
+                    );
+                    var manager1 = ServerManagerFactory.Get(new ConnectionBuilder("Server=unit-test-2222a"));
+                    var manager2 = ServerManagerFactory.Get(new ConnectionBuilder("Server=unit-test-2222b"));
+
+                    Assert.IsType<SingleServerManager>(manager1);
+                    Assert.IsType<StubServerManager>(manager2);
+                }
+                finally 
+                {
+                    ServerManagerFactory.SetAlternateManagerCreationCallback(null);
+                }
+            }
+        }
+
+        public class StubServerManager : IServerManager 
+        {
+            public IEnumerator<Server> GetEnumerator() 
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() 
+            {
+                return GetEnumerator();
+            }
+
+            public bool HasNext { get; private set; }
+            
+            public Server Next() 
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ErrorOccurred(Server server, Exception exc = null) 
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Add(Server server) 
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Remove(Server server) 
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/FluentCassandra.Tests/Connections/SingleServerManagerTests.cs
+++ b/test/FluentCassandra.Tests/Connections/SingleServerManagerTests.cs
@@ -1,27 +1,23 @@
 ﻿using System;
 using Xunit;
 
-namespace FluentCassandra.Connections
+namespace FluentCassandra.Connections 
 {
-	public class SingleServerManagerTests
-	{
-		[Fact]
-		public void CanGetServerAfterError()
-		{
-			SingleServerManager target = new SingleServerManager(new ConnectionBuilder("Server=unit-test-1"));
 
-			Server original = target.Next();
+    public class SingleServerManagerTests
+    {
+    
+        [Fact]
+        public void HasNextIsFalseAfterServerFailure()
+        {
 
-			for (int i = 0; i < 10; i++)
-			{
-				Assert.True(target.HasNext, "SingleServerManager should always have another server available.");
-				
-				Server next = target.Next();
-				Assert.True(original.ToString().Equals(next.ToString(), StringComparison.OrdinalIgnoreCase), "SingleServerManager always returns the same server.");
+            var manager = new SingleServerManager(new ConnectionBuilder("Server=unit-test-1"));
+            
+            Assert.True(manager.HasNext, "SingleServerManager was not initialized with a server");
+            var server = manager.Next();
+            manager.ErrorOccurred(server,new Exception());
 
-				//mark the server as failing to set up the next test iteration.
-				target.ErrorOccurred(next);
-			}
-		}
-	}
+            Assert.False(manager.HasNext, "SingleServerManager still has a server after its failure");
+        }
+    }
 }

--- a/test/FluentCassandra.Tests/Connections/SingleServerManagerTests.cs
+++ b/test/FluentCassandra.Tests/Connections/SingleServerManagerTests.cs
@@ -4,20 +4,20 @@ using Xunit;
 namespace FluentCassandra.Connections 
 {
 
-    public class SingleServerManagerTests
-    {
-    
-        [Fact]
-        public void HasNextIsFalseAfterServerFailure()
-        {
+	public class SingleServerManagerTests
+	{
+	
+		[Fact]
+		public void HasNextIsFalseAfterServerFailure()
+		{
 
-            var manager = new SingleServerManager(new ConnectionBuilder("Server=unit-test-1"));
-            
-            Assert.True(manager.HasNext, "SingleServerManager was not initialized with a server");
-            var server = manager.Next();
-            manager.ErrorOccurred(server,new Exception());
+			var manager = new SingleServerManager(new ConnectionBuilder("Server=unit-test-1"));
+			
+			Assert.True(manager.HasNext, "SingleServerManager was not initialized with a server");
+			var server = manager.Next();
+			manager.ErrorOccurred(server,new Exception());
 
-            Assert.False(manager.HasNext, "SingleServerManager still has a server after its failure");
-        }
-    }
+			Assert.False(manager.HasNext, "SingleServerManager still has a server after its failure");
+		}
+	}
 }

--- a/test/FluentCassandra.Tests/FluentCassandra.Tests.csproj
+++ b/test/FluentCassandra.Tests/FluentCassandra.Tests.csproj
@@ -49,8 +49,10 @@
     <Compile Include="BigDecimalTest.cs" />
     <Compile Include="Bugs\Issue28GuidGeneratorInParallelContext.cs" />
     <Compile Include="Bugs\Issue65ServerTimeoutLost.cs" />
-    <Compile Include="Connections\SingleServerManagerTests.cs" />
+    <Compile Include="Connections\InfallibleSingleServerManagerTests.cs" />
     <Compile Include="Connections\RoundRobinServerManagerTests.cs" />
+    <Compile Include="Connections\ServerManagerFactoryTests.cs" />
+    <Compile Include="Connections\SingleServerManagerTests.cs" />
     <Compile Include="CqlHelperTest.cs" />
     <Compile Include="Helper.cs" />
     <Compile Include="Operations\CassandraIndexClauseTest.cs" />


### PR DESCRIPTION
- Changed SingleServerManager to fail and stay failed until ServerPoll interval retries, or a new server is added
- Moved old SingleServerManager implementation to InfallibleSingleServerManager
- Added a callback to ServerManagerFactory so that customer ServerManagers can be returned other than the default SingleServerManager and RoundRobinServerManager
