### PR TITLE
Fixed regression caused by fix to issue #83. 

### DIFF
--- a/src/Types/DecimalTypeConverter.cs
+++ b/src/Types/DecimalTypeConverter.cs
@@ -94,41 +94,5 @@ namespace FluentCassandra.Types
 
 			return null;
 		}
-
-		public override byte[] ToBigEndian(BigDecimal value)
-		{
-			var scale = value.Scale;
-			var number = value.UnscaledValue;
-
-			var int32Converter = new Int32TypeConverter();
-			var bigIntegerConverter = new IntegerTypeConverter();
-
-			var scaleBytes = int32Converter.ToBigEndian(scale);
-			var numberBytes = bigIntegerConverter.ToBigEndian(number);
-
-			var bytes = new byte[scaleBytes.Length + numberBytes.Length];
-
-			Array.Copy(scaleBytes, 0, bytes, 0, scaleBytes.Length);
-			Array.Copy(numberBytes, 0, bytes, scaleBytes.Length, numberBytes.Length);
-
-			return bytes;
-		}
-
-		public override BigDecimal FromBigEndian(byte[] value)
-		{
-			var scaleBytes = new byte[4];
-			var numberBytes = new byte[value.Length - 4];
-
-			Array.Copy(value, 0, scaleBytes, 0, scaleBytes.Length);
-			Array.Copy(value, scaleBytes.Length, numberBytes, 0, numberBytes.Length);
-
-			var int32Converter = new Int32TypeConverter();
-			var bigIntegerConverter = new IntegerTypeConverter();
-
-			var scale = int32Converter.FromBigEndian(scaleBytes);
-			var number = bigIntegerConverter.FromBigEndian(numberBytes);
-
-			return new BigDecimal(number, scale);
-		}
 	}
 }


### PR DESCRIPTION
If a null value is found in a decimal type column then you'll get a NullReferenceException when reading it out.
Handling null values was originally fixed in pull request #78 but then it regressed for the decimal type in the fix for issue #83.

Also from what I can tell it looks like the byte ordering for decimals was working all along and the fix for issue #83 isn't needed? I verified this by writing a decimal value using the library and reading with cqlsh without any issues. Finally the tests in DecimalTypeTest.cs pass on the parent of d05b40e1a58f2a6c466c71bd51232d5272938512 (the fix for issue #83).
